### PR TITLE
more blog styles pt3

### DIFF
--- a/components/card/index.js
+++ b/components/card/index.js
@@ -97,7 +97,11 @@ const Card = ({
         {categories && (
           <>
             <span className="separator">|</span>
-            <span className="bold">{categories[0].name}</span>
+            {/* eslint-disable-next-line react/no-danger */}
+            <span
+              className="bold"
+              dangerouslySetInnerHTML={{ __html: categories[0].name }}
+            />
           </>
         )}
         <span className="separator">|</span>

--- a/components/category-list/index.js
+++ b/components/category-list/index.js
@@ -26,9 +26,9 @@ const CategoryList = ({
             className={
               selectedCategories.includes(category.slug) ? 'selected' : 'span'
             }
-          >
-            {category.name}
-          </span>
+            // eslint-disable-next-line react/no-danger
+            dangerouslySetInnerHTML={{ __html: category.name }}
+          />
         </a>
       ))}
       {children}

--- a/layouts/post/index.js
+++ b/layouts/post/index.js
@@ -281,7 +281,7 @@ const Post = ({
           max-width: 90rem;
         `}
       >
-        <Column width={[1, 1 / 4]}>
+        <Column width={[1, 1 / 5]}>
           <PostMetaDesktop>
             <PostMeta categories={post.categories} tags={post.tags}>
               {languagesForDropdown.length !== 0 && (

--- a/layouts/post/meta/index.js
+++ b/layouts/post/meta/index.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/no-danger */
 import React from 'react';
 import PropTypes from 'prop-types';
 
@@ -20,7 +21,10 @@ const PostMeta = ({ categories, tags, children }) => {
               categories.map((category, index) => (
                 <li key={index}>
                   <Link key={category.id} href={category.link}>
-                    <span className="link">{category.name}</span>
+                    <span
+                      className="link"
+                      dangerouslySetInnerHTML={{ __html: category.name }}
+                    />
                   </Link>
                 </li>
               ))}
@@ -36,7 +40,10 @@ const PostMeta = ({ categories, tags, children }) => {
               filteredTags.map((tag, index) => (
                 <li key={index}>
                   <Link key={tag.id} href={tag.link}>
-                    <span className="link">{tag.name}</span>
+                    <span
+                      className="link"
+                      dangerouslySetInnerHTML={{ __html: tag.name }}
+                    />
                   </Link>
                 </li>
               ))}

--- a/layouts/post/share-links/styles.js
+++ b/layouts/post/share-links/styles.js
@@ -4,10 +4,12 @@ import { theme } from '@worldresources/gfw-components';
 export const ButtonsContainer = styled.div`
   display: flex;
   flex-direction: row;
+  justify-content: center;
+  margin-bottom: 3rem;
 
   > a,
   > button {
-    margin: 0 1.25rem 1.25rem 0;
+    margin: 0.5rem;
   }
 `;
 


### PR DESCRIPTION
addresses:

For mobile, the last three social buttons don't align with the article / category / topics
I'm seeing the data category show up as "data&” in various spots on the site
In the design on desktop the width of the column for the body of the blog is wider - it goes further to the left. It's also aligned left with the title of the post. The graphics in the body should also aligned left with the text - on the staging site, the graphics extend a little further to the left. Also, the body paragraph text looks a little different - I think slightly smaller in the design. The header styles also look different in the design.


